### PR TITLE
Add the Key field to VoucherifyClientException

### DIFF
--- a/src/Voucherify/Core/Exceptions/VoucherifyClientException.cs
+++ b/src/Voucherify/Core/Exceptions/VoucherifyClientException.cs
@@ -18,6 +18,9 @@ namespace Voucherify.Core.Exceptions
         [JsonProperty(PropertyName = "details")]
         public string Details { get; private set; }
 
+        [JsonProperty(PropertyName = "key")]
+        public string Key { get; private set; }
+
         public VoucherifyClientException() { }
 
         public VoucherifyClientException(string message, int code, string details)


### PR DESCRIPTION
According to the Voucherify documentation [here](https://docs.voucherify.io/v1/reference#errors), in case of any error when a client calls the Voucherify API, the service returns a json object with the following four fields: 
- code
- **key**
- message
- details 

In the .NET client for Voucherify all these fields except **key** become values of a _VoucherifyClientException_ instance which gets thrown when an error occurs.

It makes it harder to handle errors occurred on the Voucherify side because the **key** field contains machine-readable error code.

This PR contains a change that adds the **key** field to _VoucherifyClientException_