### PR TITLE
Added the 'applicable_to' product list to the voucher.

### DIFF
--- a/src/Voucherify/DataModel/ApplicableProductList.cs
+++ b/src/Voucherify/DataModel/ApplicableProductList.cs
@@ -1,0 +1,25 @@
+﻿#if VOUCHERIFYSERVER
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Voucherify.Core.DataModel;
+
+namespace Voucherify.DataModel
+{
+    [JsonObject]
+    public class ApplicableProductList : ApiObject
+    {
+        [JsonProperty(PropertyName = "total")]
+        public int? Total { get; private set; }
+
+        [JsonProperty(PropertyName = "data")]
+        public List<Product> Products { get; private set; }
+
+        public override string ToString()
+        {
+            return string.Format("ProductList[Entries={0}]", this.Total);
+        }
+    }
+}
+#endif

--- a/src/Voucherify/DataModel/Voucher.cs
+++ b/src/Voucherify/DataModel/Voucher.cs
@@ -53,6 +53,9 @@ namespace Voucherify.DataModel
         [JsonProperty(PropertyName = "metadata")]
         public Metadata Metadata { get; private set; }
 
+        [JsonProperty(PropertyName = "applicable_to")]
+        public ApplicableProductList ApplicableTo { get; private set; }
+
         public Voucher()
         {
             this.Metadata = new Metadata();
@@ -60,7 +63,7 @@ namespace Voucherify.DataModel
 
         public override string ToString()
         {
-            return string.Format("Voucher[Code={0},Type={1},Campaign={2},Category={3},Discount={4},Gift={5},Start={6},Expiration={7},Active={8},Publish={9},Redemption={10},Additional={11},Metadata={12}]",
+            return string.Format("Voucher[Code={0},Type={1},Campaign={2},Category={3},Discount={4},Gift={5},Start={6},Expiration={7},Active={8},Publish={9},Redemption={10},Additional={11},Metadata={12},ApplicableTo={13}]",
                 this.Code,
                 this.Type,
                 this.Campaign,
@@ -73,7 +76,8 @@ namespace Voucherify.DataModel
                 this.Publish,
                 this.Redemption,
                 this.AdditionalInfo,
-                this.Metadata);
+                this.Metadata,
+                this.ApplicableTo);
         }
     }
 }

--- a/src/Voucherify/Voucherify.Client.net20.csproj
+++ b/src/Voucherify/Voucherify.Client.net20.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Client\ApiEndpoints\Validations.Callback.cs" />
     <Compile Include="Client\ApiEndpoints\Vouchers.Async.cs" />
     <Compile Include="Client\ApiEndpoints\Vouchers.Callback.cs" />
+    <Compile Include="DataModel\ApplicableProductList.cs" />
     <Compile Include="DataModel\CampaignVoucher.cs" />
     <Compile Include="DataModel\CampaignVoucherRedemption.cs" />
     <Compile Include="DataModel\Contexts\CampaignVoucherCreate.cs" />

--- a/src/Voucherify/Voucherify.Client.net35.Unity.csproj
+++ b/src/Voucherify/Voucherify.Client.net35.Unity.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Core\Serialization\JsonSerializer.cs" />
     <Compile Include="Core\Serialization\MetadataConverter.cs" />
     <Compile Include="Core\Serialization\QuerySerializer.cs" />
+    <Compile Include="DataModel\ApplicableProductList.cs" />
     <Compile Include="DataModel\Campaign.cs" />
     <Compile Include="DataModel\CampaignVoucher.cs" />
     <Compile Include="DataModel\CampaignVoucherRedemption.cs" />

--- a/src/Voucherify/Voucherify.Client.net35.csproj
+++ b/src/Voucherify/Voucherify.Client.net35.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Core\Serialization\JsonSerializer.cs" />
     <Compile Include="Core\Serialization\MetadataConverter.cs" />
     <Compile Include="Core\Serialization\QuerySerializer.cs" />
+    <Compile Include="DataModel\ApplicableProductList.cs" />
     <Compile Include="DataModel\Campaign.cs" />
     <Compile Include="DataModel\CampaignVoucher.cs" />
     <Compile Include="DataModel\CampaignVoucherRedemption.cs" />

--- a/src/Voucherify/Voucherify.Client.net40.csproj
+++ b/src/Voucherify/Voucherify.Client.net40.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Core\Serialization\JsonSerializer.cs" />
     <Compile Include="Core\Serialization\MetadataConverter.cs" />
     <Compile Include="Core\Serialization\QuerySerializer.cs" />
+    <Compile Include="DataModel\ApplicableProductList.cs" />
     <Compile Include="DataModel\Campaign.cs" />
     <Compile Include="DataModel\CampaignVoucher.cs" />
     <Compile Include="DataModel\CampaignVoucherRedemption.cs" />

--- a/src/Voucherify/Voucherify.Client.net45.Portable.csproj
+++ b/src/Voucherify/Voucherify.Client.net45.Portable.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Core\Serialization\JsonSerializer.cs" />
     <Compile Include="Core\Serialization\MetadataConverter.cs" />
     <Compile Include="Core\Serialization\QuerySerializer.cs" />
+    <Compile Include="DataModel\ApplicableProductList.cs" />
     <Compile Include="DataModel\Campaign.cs" />
     <Compile Include="DataModel\CampaignVoucher.cs" />
     <Compile Include="DataModel\CampaignVoucherRedemption.cs" />

--- a/src/Voucherify/Voucherify.Client.net45.csproj
+++ b/src/Voucherify/Voucherify.Client.net45.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Core\Serialization\JsonSerializer.cs" />
     <Compile Include="Core\Serialization\MetadataConverter.cs" />
     <Compile Include="Core\Serialization\QuerySerializer.cs" />
+    <Compile Include="DataModel\ApplicableProductList.cs" />
     <Compile Include="DataModel\Campaign.cs" />
     <Compile Include="DataModel\CampaignVoucher.cs" />
     <Compile Include="DataModel\CampaignVoucherRedemption.cs" />

--- a/src/Voucherify/Voucherify.net20.csproj
+++ b/src/Voucherify/Voucherify.net20.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Core\Serialization\JsonSerializer.cs" />
     <Compile Include="Core\Serialization\MetadataConverter.cs" />
     <Compile Include="Core\Serialization\QuerySerializer.cs" />
+    <Compile Include="DataModel\ApplicableProductList.cs" />
     <Compile Include="DataModel\Campaign.cs" />
     <Compile Include="DataModel\CampaignVoucher.cs" />
     <Compile Include="DataModel\CampaignVoucherRedemption.cs" />

--- a/src/Voucherify/Voucherify.net35.csproj
+++ b/src/Voucherify/Voucherify.net35.csproj
@@ -99,6 +99,7 @@
     <Compile Include="DataModel\Order.cs" />
     <Compile Include="DataModel\OrderItem.cs" />
     <Compile Include="DataModel\Product.cs" />
+    <Compile Include="DataModel\ApplicableProductList.cs" />
     <Compile Include="DataModel\ProductList.cs" />
     <Compile Include="DataModel\ProductSkus.cs" />
     <Compile Include="DataModel\QR.cs" />

--- a/src/Voucherify/Voucherify.net40.csproj
+++ b/src/Voucherify/Voucherify.net40.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Core\Serialization\JsonSerializer.cs" />
     <Compile Include="Core\Serialization\MetadataConverter.cs" />
     <Compile Include="Core\Serialization\QuerySerializer.cs" />
+    <Compile Include="DataModel\ApplicableProductList.cs" />
     <Compile Include="DataModel\Campaign.cs" />
     <Compile Include="DataModel\CampaignVoucher.cs" />
     <Compile Include="DataModel\CampaignVoucherRedemption.cs" />

--- a/src/Voucherify/Voucherify.net45.Portable.csproj
+++ b/src/Voucherify/Voucherify.net45.Portable.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Core\Serialization\JsonSerializer.cs" />
     <Compile Include="Core\Serialization\MetadataConverter.cs" />
     <Compile Include="Core\Serialization\QuerySerializer.cs" />
+    <Compile Include="DataModel\ApplicableProductList.cs" />
     <Compile Include="DataModel\Campaign.cs" />
     <Compile Include="DataModel\CampaignVoucher.cs" />
     <Compile Include="DataModel\CampaignVoucherRedemption.cs" />

--- a/src/Voucherify/Voucherify.net45.csproj
+++ b/src/Voucherify/Voucherify.net45.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Core\Serialization\JsonSerializer.cs" />
     <Compile Include="Core\Serialization\MetadataConverter.cs" />
     <Compile Include="Core\Serialization\QuerySerializer.cs" />
+    <Compile Include="DataModel\ApplicableProductList.cs" />
     <Compile Include="DataModel\Campaign.cs" />
     <Compile Include="DataModel\CampaignVoucher.cs" />
     <Compile Include="DataModel\CampaignVoucherRedemption.cs" />


### PR DESCRIPTION
Hello Voucherify

There were some issues where the API was returning information about which product the discount was applicable to, but we couldn't use it because it was not being deserialized. 

So solve this, I took the liberty to:
- Add a new class called the 'ApplicationProductList' because the format is a little bit different than a normal product list. The json property 'data' is being used instead of 'products'.

Below a sample of the response we are getting from your API's 😄 


```
// https://api.voucherify.io/v1/vouchers/VOUCHERCODE
{
    "code": "VOUCHERCODE",
    "campaign": "campaign",
    "category": null,
    "type": "DISCOUNT_VOUCHER",
    "discount": {
        "type": "PERCENT",
        "percent_off": 10
    },
    "gift": null,
    "start_date": null,
    "expiration_date": null,
    ...
    // Ommited
    ...
    "applicable_to": {
        "object": "list",
        "total": 1,
        "data": [
            {
                "object": "product",
                "id": "prod_zKAoFwKKjfWKc1",
                "source_id": "23"
            }
        ]
    }
}
```