### PR TITLE
Add stackable validation and stackable redemption endpoint support

### DIFF
--- a/src/Voucherify/ApiEndpoints/Redemptions.Async.cs
+++ b/src/Voucherify/ApiEndpoints/Redemptions.Async.cs
@@ -29,7 +29,13 @@ namespace Voucherify.ApiEndpoints
             UriBuilder uriBuilder = UriBuilderExtension.WithQuery(this.client.GetUriBuilder(string.Format("/vouchers/{0}/redemption", UriBuilderExtension.EnsureEscapedDataString("code", code))), query);
             return await this.client.DoPostRequest<DataModel.Redemption, DataModel.Contexts.RedemptionRedeem>(uriBuilder.Uri, context).ConfigureAwait(false);
         }
-        
+
+        public async Task<DataModel.StackableRedemption> Redeem(DataModel.Contexts.StackableRedemptionRedeem context)
+        {
+            UriBuilder uriBuilder = this.client.GetUriBuilder("/redemptions");
+            return await this.client.DoPostRequest<DataModel.StackableRedemption, DataModel.Contexts.StackableRedemptionRedeem>(uriBuilder.Uri, context).ConfigureAwait(false);
+        }
+
         public async Task<DataModel.Redemption> RedeemVoucher(string code, DataModel.Queries.RedemptionRedeem query, DataModel.Contexts.RedemptionRedeem context)
         {
             UriBuilder uriBuilder = UriBuilderExtension.WithQuery(this.client.GetUriBuilder(string.Format("/vouchers/{0}/redemption", UriBuilderExtension.EnsureEscapedDataString("code", code))), query);

--- a/src/Voucherify/ApiEndpoints/Redemptions.Callback.cs
+++ b/src/Voucherify/ApiEndpoints/Redemptions.Callback.cs
@@ -30,6 +30,12 @@ namespace Voucherify.ApiEndpoints
             this.client.DoPostRequest(uriBuilder.Uri, context, callback);
         }
 
+        public void Redeem(DataModel.Contexts.StackableRedemptionRedeem context, Action<ApiResponse<DataModel.StackableRedemption>> callback)
+        {
+            UriBuilder uriBuilder = this.client.GetUriBuilder("/redemptions");
+            this.client.DoPostRequest(uriBuilder.Uri, context, callback);
+        }
+
         public void RedeemVoucher(string code, DataModel.Queries.RedemptionRedeem query, DataModel.Contexts.RedemptionRedeem context, Action<ApiResponse<DataModel.Redemption>> callback)
         {
             UriBuilder uriBuilder = UriBuilderExtension.WithQuery(this.client.GetUriBuilder(string.Format("/vouchers/{0}/redemption", UriBuilderExtension.EnsureEscapedDataString("code", code))), query);

--- a/src/Voucherify/ApiEndpoints/Validations.Async.cs
+++ b/src/Voucherify/ApiEndpoints/Validations.Async.cs
@@ -39,6 +39,12 @@ namespace Voucherify.ApiEndpoints
 
             return await this.client.DoPostRequest<DataModel.Validation, DataModel.Contexts.Validation>(uriBuilder.Uri, context).ConfigureAwait(false);
         }
+
+        public async Task<DataModel.StackableValidation> Validate(DataModel.Contexts.StackableValidation context)
+        {
+            UriBuilder uriBuilder = this.client.GetUriBuilder("/validations");
+            return await this.client.DoPostRequest<DataModel.StackableValidation, DataModel.Contexts.StackableValidation>(uriBuilder.Uri, context).ConfigureAwait(false);
+        }
     }
 }
 

--- a/src/Voucherify/ApiEndpoints/Validations.Callback.cs
+++ b/src/Voucherify/ApiEndpoints/Validations.Callback.cs
@@ -41,6 +41,12 @@ namespace Voucherify.ApiEndpoints
              
             this.client.DoPostRequest(uriBuilder.Uri, context, callback);
         }
+
+        public void Validate(DataModel.Contexts.StackableValidation context, Action<ApiResponse<DataModel.StackableValidation>> callback)
+        {
+            UriBuilder uriBuilder = this.client.GetUriBuilder("/validationS");
+            this.client.DoPostRequest(uriBuilder.Uri, context, callback);
+        }
     }
 }
 

--- a/src/Voucherify/DataModel/Contexts/Redeemable.cs
+++ b/src/Voucherify/DataModel/Contexts/Redeemable.cs
@@ -1,0 +1,22 @@
+﻿#if VOUCHERIFYSERVER || VOUCHERIFYCLIENT
+using Newtonsoft.Json;
+
+namespace Voucherify.DataModel.Contexts
+{
+    [JsonObject]
+    public class Redeemable
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+
+        [JsonProperty(PropertyName = "object")]
+        public string Object { get; set; }
+
+        [JsonProperty(PropertyName = "reward")]
+        public RedeemableReward Reward { get; set; }
+
+        [JsonProperty(PropertyName = "gift")]
+        public RedeemableGift Gift { get; set; }
+    }
+}
+#endif

--- a/src/Voucherify/DataModel/Contexts/RedeemableGift.cs
+++ b/src/Voucherify/DataModel/Contexts/RedeemableGift.cs
@@ -1,0 +1,13 @@
+﻿#if VOUCHERIFYSERVER || VOUCHERIFYCLIENT
+using Newtonsoft.Json;
+
+namespace Voucherify.DataModel.Contexts
+{
+    [JsonObject]
+    public class RedeemableGift
+    {
+        [JsonProperty(PropertyName = "credits")]
+        public long? Credits { get; set; }
+    }
+}
+#endif

--- a/src/Voucherify/DataModel/Contexts/RedeemableReward.cs
+++ b/src/Voucherify/DataModel/Contexts/RedeemableReward.cs
@@ -1,0 +1,19 @@
+﻿#if VOUCHERIFYSERVER || VOUCHERIFYCLIENT
+using Newtonsoft.Json;
+
+namespace Voucherify.DataModel.Contexts
+{
+    [JsonObject]
+    public class RedeemableReward
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+
+        [JsonProperty(PropertyName = "assignment_id")]
+        public string AssignmentId { get; set; }
+
+        [JsonProperty(PropertyName = "points")]
+        public long? Points { get; set; }
+    }
+}
+#endif

--- a/src/Voucherify/DataModel/Contexts/StackableRedemptionOptions.cs
+++ b/src/Voucherify/DataModel/Contexts/StackableRedemptionOptions.cs
@@ -1,0 +1,45 @@
+﻿#if VOUCHERIFYSERVER || VOUCHERIFYCLIENT
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Voucherify.DataModel.Contexts
+{
+    [JsonObject]
+    public class StackableRedemptionOptions
+    {
+        [JsonProperty(PropertyName = "expand")]
+        public HashSet<string> Expand { get; set; }
+
+        public StackableRedemptionOptions()
+        {
+            this.Expand = new HashSet<string>();
+        }
+
+        public StackableRedemptionOptions WithOrder()
+        {
+            this.Expand.Add("order");
+            return this;
+        }
+
+        public StackableRedemptionOptions WithRedeemable()
+        {
+            this.Expand.Add("redeemable");
+            return this;
+        }
+
+        public StackableRedemptionOptions WithCategory()
+        {
+            this.Expand.Add("category");
+            return this;
+        }
+
+        public StackableRedemptionOptions WithRedemption()
+        {
+            this.Expand.Add("redemption");
+            return this;
+        }
+    }
+}
+#endif

--- a/src/Voucherify/DataModel/Contexts/StackableRedemptionRedeem.cs
+++ b/src/Voucherify/DataModel/Contexts/StackableRedemptionRedeem.cs
@@ -1,0 +1,36 @@
+﻿#if VOUCHERIFYSERVER || VOUCHERIFYCLIENT
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using Voucherify.Core.DataModel;
+
+namespace Voucherify.DataModel.Contexts
+{
+    [JsonObject]
+    public class StackableRedemptionRedeem
+    {
+        [JsonProperty(PropertyName = "customer")]
+        public Customer Customer { get; set; }
+
+        [JsonProperty(PropertyName = "order")]
+        public Order Order { get; set; }
+
+        [JsonProperty(PropertyName = "options")]
+        public StackableRedemptionOptions Options { get; set; }
+
+        [JsonProperty(PropertyName = "redeemables")]
+        public List<Redeemable> Redeemables { get; set; }
+
+        [JsonProperty(PropertyName = "metadata")]
+        public Metadata Metadata { get; set; }
+
+        [JsonProperty(PropertyName = "session")]
+        public ValidationSession Session { get; set; }
+
+        public StackableRedemptionRedeem()
+        {
+            this.Redeemables = new List<Redeemable>();
+            this.Metadata = new Metadata();
+        }
+    }
+}
+#endif

--- a/src/Voucherify/DataModel/Contexts/StackableValidation.cs
+++ b/src/Voucherify/DataModel/Contexts/StackableValidation.cs
@@ -1,0 +1,38 @@
+﻿#if VOUCHERIFYSERVER || VOUCHERIFYCLIENT
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Voucherify.Core.DataModel;
+
+namespace Voucherify.DataModel.Contexts
+{
+    [JsonObject]
+    public class StackableValidation
+    {
+        [JsonProperty(PropertyName = "customer")]
+        public Customer Customer { get; set; }
+
+        [JsonProperty(PropertyName = "order")]
+        public Order Order { get; set; }
+
+        [JsonProperty(PropertyName = "options")]
+        public StackableValidationOptions Options { get; set; }
+
+        [JsonProperty(PropertyName = "redeemables")]
+        public List<Redeemable> Redeemables { get; set; }
+
+        [JsonProperty(PropertyName = "metadata")]
+        public Metadata Metadata { get; set; }
+
+        [JsonProperty(PropertyName = "session")]
+        public ValidationSession Session { get; set; }
+
+        public StackableValidation()
+        {
+            this.Redeemables = new List<Redeemable>();
+            this.Metadata = new Metadata();
+        }
+    }
+}
+#endif

--- a/src/Voucherify/DataModel/Contexts/StackableValidationOptions.cs
+++ b/src/Voucherify/DataModel/Contexts/StackableValidationOptions.cs
@@ -1,0 +1,39 @@
+﻿#if VOUCHERIFYSERVER || VOUCHERIFYCLIENT
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Voucherify.DataModel.Contexts
+{
+    [JsonObject]
+    public class StackableValidationOptions
+    {
+        [JsonProperty(PropertyName = "expand")]
+        public HashSet<string> Expand { get; set; }
+
+        public StackableValidationOptions()
+        {
+            this.Expand = new HashSet<string>();
+        }
+
+        public StackableValidationOptions WithOrder()
+        {
+            this.Expand.Add("order");
+            return this;
+        }
+
+        public StackableValidationOptions WithRedeemable()
+        {
+            this.Expand.Add("redeemable");
+            return this;
+        }
+
+        public StackableValidationOptions WithCategory()
+        {
+            this.Expand.Add("category");
+            return this;
+        }
+    }
+}
+#endif

--- a/src/Voucherify/DataModel/Order.cs
+++ b/src/Voucherify/DataModel/Order.cs
@@ -39,15 +39,19 @@ namespace Voucherify.DataModel
         [JsonProperty(PropertyName = "metadata")]
         public Metadata Metadata { get; private set; }
 
+        [JsonProperty(PropertyName = "redemptions")]
+        public Dictionary<string, OrderRedemption> Redemptions { get; private set; }
+
         public Order() {
             this.Items = new List<OrderItem>();
             this.Metadata = new Metadata();
+            this.Redemptions = new Dictionary<string, OrderRedemption>();
         }
 
         public override string ToString()
         {
             return string.Format("Order(Id={0},SourceId={1},Status={2},Amount={3},DiscountAmount={4},TotalDiscountAmount={5},TotalAmount={6},Items={7})", 
-                this.Id, this.SourceId, this.Status, this.Amount, this.DiscountAmount, this.TotalDiscountAmount, this.TotalAmount, ListExtensions.ToString<OrderItem>(this.Items));
+                this.Id, this.SourceId, this.Status, this.Amount, this.DiscountAmount, this.TotalDiscountAmount, this.TotalAmount, ListExtensions.ToString(this.Items));
         }
     }
 }

--- a/src/Voucherify/DataModel/OrderItem.cs
+++ b/src/Voucherify/DataModel/OrderItem.cs
@@ -37,6 +37,13 @@ namespace Voucherify.DataModel
         [JsonProperty(PropertyName = "discount_amount")]
         public long? DiscountAmount { get; private set; }
 
+        [JsonProperty(PropertyName = "metadata")]
+        public Metadata Metadata { get; private set; }
+
+        public OrderItem() {
+            this.Metadata = new Metadata();
+        }
+
         public OrderItem WithSourceId(string sourceId, string relatedObject)
         {
             this.SourceId = sourceId;

--- a/src/Voucherify/DataModel/OrderRedemption.cs
+++ b/src/Voucherify/DataModel/OrderRedemption.cs
@@ -1,0 +1,35 @@
+﻿#if VOUCHERIFYSERVER || VOUCHERIFYCLIENT
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using Voucherify.Core.Extensions;
+
+namespace Voucherify.DataModel
+{
+    [JsonObject]
+    public class OrderRedemption
+    {
+        [JsonProperty(PropertyName = "date")]
+        public DateTime? Date { get; private set; }
+
+        [JsonProperty("related_object_id")]
+        public string RelatedObjectId { get; private set; }
+
+        [JsonProperty("related_object_type")]
+        public string RelatedObjectType { get; private set; }
+
+        [JsonProperty("stacked")]
+        public List<string> Stacked { get; private set; }
+
+        public OrderRedemption()
+        {
+            this.Stacked = new List<string>();
+        }
+
+        public override string ToString()
+        {
+            return string.Format("OrderRedemption(Date={0},RelatedObjectId={1},RelatedObjectType={2},Stacked={3})", this.Date, this.RelatedObjectId, this.RelatedObjectType, ListExtensions.ToString(this.Stacked));
+        }
+    }
+}
+#endif

--- a/src/Voucherify/DataModel/Redeemable.cs
+++ b/src/Voucherify/DataModel/Redeemable.cs
@@ -1,0 +1,43 @@
+﻿#if VOUCHERIFYSERVER || VOUCHERIFYCLIENT
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Voucherify.Core.DataModel;
+
+namespace Voucherify.DataModel
+{
+    [JsonObject]
+    public class Redeemable
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; private set; }
+
+        [JsonProperty(PropertyName = "object")]
+        public string Object { get; private set; }
+
+        [JsonProperty(PropertyName = "status")]
+        public string Status { get; private set; }
+
+        [JsonProperty(PropertyName = "order")]
+        public Order Order { get; private set; }
+
+        [JsonProperty(PropertyName = "applicable_to")]
+        public VoucherSubjectList ApplicableTo { get; private set; }
+
+        [JsonProperty(PropertyName = "inapplicable_to")]
+        public VoucherSubjectList InapplicableTo { get; private set; }
+
+        [JsonProperty(PropertyName = "result")]
+        public RedeemableResult Result { get; private set; }
+
+        [JsonProperty(PropertyName = "metadata")]
+        public Metadata Metadata { get; private set; }
+
+        public override string ToString()
+        {
+            return string.Format("Redeemable(Id={0},Object={1},Status={2},Order={3},ApplicableTo={4},InapplicableTo={5},Result={6},Metadata={7})", this.Id, this.Object, this.Status, this.Order, this.ApplicableTo, this.InapplicableTo, this.Result, this.Metadata);
+        }
+    }
+}
+#endif

--- a/src/Voucherify/DataModel/RedeemableResult.cs
+++ b/src/Voucherify/DataModel/RedeemableResult.cs
@@ -1,0 +1,21 @@
+﻿#if VOUCHERIFYSERVER || VOUCHERIFYCLIENT
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Voucherify.DataModel
+{
+    [JsonObject]
+    public class RedeemableResult
+    {
+        [JsonProperty(PropertyName = "discount")]
+        public Discount Discount { get; private set; }
+
+        public override string ToString()
+        {
+            return string.Format("RedeemableResult(Discount={0})", this.Discount);
+        }
+    }
+}
+#endif

--- a/src/Voucherify/DataModel/Redemption.cs
+++ b/src/Voucherify/DataModel/Redemption.cs
@@ -44,9 +44,12 @@ namespace Voucherify.DataModel
         [JsonProperty(PropertyName = "amount", NullValueHandling = NullValueHandling.Ignore)]
         public long Amount { get; private set; }
 
+        [JsonProperty(PropertyName = "redemption")]
+        public string ParentRedemptionId { get; private set; }
+
         public override string ToString()
         {
-            return string.Format("Redemption(Id={0},Result={1},Customer={2},Tracking={3},Order={4})", this.Id, this.Result, this.CustomerId, this.TrackingId, this.Order);
+            return string.Format("Redemption(Id={0},Result={1},Customer={2},Tracking={3},Order={4},Redemption={5})", this.Id, this.Result, this.CustomerId, this.TrackingId, this.Order, this.ParentRedemptionId);
         }
     }
 }

--- a/src/Voucherify/DataModel/StackableRedemption.cs
+++ b/src/Voucherify/DataModel/StackableRedemption.cs
@@ -1,0 +1,33 @@
+﻿#if VOUCHERIFYSERVER || VOUCHERIFYCLIENT
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Voucherify.Core.Extensions;
+
+namespace Voucherify.DataModel
+{
+    [JsonObject]
+    public class StackableRedemption
+    {
+        [JsonProperty(PropertyName = "redemptions")]
+        public List<Redemption> Redemptions { get; private set; }
+
+        [JsonProperty(PropertyName = "parent_redemption")]
+        public Redemption ParentRedemption { get; private set; }
+
+        [JsonProperty(PropertyName = "order")]
+        public Order Order { get; private set; }
+
+        public StackableRedemption()
+        {
+            this.Redemptions = new List<Redemption>();
+        }
+
+        public override string ToString()
+        {
+            return string.Format("StackableRedemption(Redemptions={0},ParentRedemption={1},Order={2})", ListExtensions.ToString(this.Redemptions), this.ParentRedemption, this.Order);
+        }
+    }
+}
+#endif

--- a/src/Voucherify/DataModel/StackableValidation.cs
+++ b/src/Voucherify/DataModel/StackableValidation.cs
@@ -1,0 +1,39 @@
+﻿#if VOUCHERIFYSERVER || VOUCHERIFYCLIENT
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Voucherify.Core.Extensions;
+
+namespace Voucherify.DataModel
+{
+    [JsonObject]
+    public class StackableValidation
+    {
+        [JsonProperty(PropertyName = "valid")]
+        public bool Valid { get; private set; }
+
+        [JsonProperty(PropertyName = "redeemables")]
+        public List<Redeemable> Redeemables { get; private set; }
+
+        [JsonProperty(PropertyName = "order")]
+        public Order Order { get; private set; }
+
+        [JsonProperty(PropertyName = "tracking_id")]
+        public string TrackingId { get; private set; }
+
+        [JsonProperty(PropertyName = "session")]
+        public ValidationSession Session { get; private set; }
+
+        public StackableValidation()
+        {
+            this.Redeemables = new List<Redeemable>();
+        }
+
+        public override string ToString()
+        {
+            return string.Format("StackableValidation(IsValid={0},Redeemables={1},Order={2},TrackingId={3},Session={4})", this.Valid, ListExtensions.ToString(this.Redeemables), this.Order, this.TrackingId, this.Session);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
According to API documentation [(https://docs.voucherify.io/reference/stacking-api-overview)](https://docs.voucherify.io/reference/stacking-api-overview) there are endpoints that allow you to validate or redeem up to 5 voucher at the same time.

According to API documentation [(https://docs.voucherify.io/reference/the-order-item-object),](https://docs.voucherify.io/reference/the-order-item-object) there is a metadata field in order item data, and that field is missing in .NET SDK.