### PR TITLE
Add missing properties in Order data model that exists in API result.

### DIFF
--- a/src/Voucherify/DataModel/Order.cs
+++ b/src/Voucherify/DataModel/Order.cs
@@ -33,6 +33,12 @@ namespace Voucherify.DataModel
         [JsonProperty(PropertyName = "total_amount", NullValueHandling = NullValueHandling.Ignore)]
         public long? TotalAmount { get; private set; }
 
+        [JsonProperty(PropertyName = "applied_discount_amount", NullValueHandling = NullValueHandling.Ignore)]
+        public long? AppliedDiscountAmount { get; private set; }
+
+        [JsonProperty(PropertyName = "total_applied_discount_amount", NullValueHandling = NullValueHandling.Ignore)]
+        public long? TotalAppliedDiscountAmount { get; private set; }
+
         [JsonProperty(PropertyName = "items")]
         public List<OrderItem> Items { get; private set; }
 


### PR DESCRIPTION
Properties that correspond to `applied_discount_amount` and `total_applied_discount_amount` fields in API response were missing  in Order data model.