### PR TITLE
Add Metadata attribute to the ValidationPromotionTier Model

### DIFF
--- a/src/Voucherify/DataModel/ValidationPromotionTier.cs
+++ b/src/Voucherify/DataModel/ValidationPromotionTier.cs
@@ -28,6 +28,14 @@ namespace Voucherify.DataModel
         [JsonProperty(PropertyName = "inapplicable_to")]
         public VoucherSubjectList InapplicableTo { get; private set; }
 
+        [JsonProperty(PropertyName = "metadata")]
+        public Metadata Metadata { get; private set; }
+
+        public ValidationPromotionTier()
+        {
+            this.Metadata = new Metadata();
+        }
+
         public override string ToString()
         {
             return string.Format("ValidationPromotionTier(Id={0},Discount={1},DiscountAmount={2},Order={3},ApplicableTo={4},InapplicableTo={5})",


### PR DESCRIPTION
Hi, when I was implementing a feature with validating promotions, I discover that the promotion tier didn't have the metadata that I define for him. So this pull request is to add metadata attribute to the ValidationPromotionTier Model.