### PR TITLE
init Metadata in Redeemable Model

### DIFF
--- a/src/Voucherify/DataModel/Redeemable.cs
+++ b/src/Voucherify/DataModel/Redeemable.cs
@@ -34,6 +34,11 @@ namespace Voucherify.DataModel
         [JsonProperty(PropertyName = "metadata")]
         public Metadata Metadata { get; private set; }
 
+        public Redeemable()
+        {
+            this.Metadata = new Metadata();
+        }
+
         public override string ToString()
         {
             return string.Format("Redeemable(Id={0},Object={1},Status={2},Order={3},ApplicableTo={4},InapplicableTo={5},Result={6},Metadata={7})", this.Id, this.Object, this.Status, this.Order, this.ApplicableTo, this.InapplicableTo, this.Result, this.Metadata);


### PR DESCRIPTION
When I was trying to use metadata in a redeemable, I discover that the metadata attribute was "null" so this PR is here for init the metadata attribute on the Redeemable Model.