### PR TITLE
Dev-3097 Pin Actions to Specific SHA

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9
         with:
           dotnet-version: "9.0.x"
 


### PR DESCRIPTION
Supply Chain Attacks - Poisoned Actions: Using Marketplace actions without pinning them to a specific commit SHA (e.g., using uses: actions/checkout@v4 instead of a unique hash). If a popular action creator's account is compromised, an attacker can push a malicious version that steals secrets (as seen in the famous tj-actions/changed-files incident).